### PR TITLE
Redesign blog listing and add draft posts

### DIFF
--- a/_drafts/2025-dnd-racialization.md
+++ b/_drafts/2025-dnd-racialization.md
@@ -1,0 +1,22 @@
+---
+title: "Orcs, Race, and Fifty Years of Dungeons & Dragons"
+author: [FILL IN: DataSquad member who worked on this]
+date: 2025-04-01  # TODO: update before publishing
+layout: blogs
+draft: true
+---
+
+<!-- DRAFT — for review before publishing.
+     Lian: please fill in the [FILL IN] placeholders below.
+     Check with the researcher that they're okay being named and that the details are accurate.
+     The post is intentionally short — resist the urge to add more sections. -->
+
+Most DataSquad projects start with something like: I have a spreadsheet and it keeps doing something weird. This one started with orcs.
+
+A graduate student in the English department was trying to figure out whether the way Dungeons & Dragons describes orcs had changed over fifty years of sourcebooks and fanzines. Specifically, whether the language describing their nature and role in the game world had shifted toward or away from real-world racial stereotypes over time. That's a genuine research question. It's also a lot of text.
+
+The method is called distant reading: instead of reading everything closely, you use computational tools to find patterns across a corpus too large to get through by hand. Getting to that point meant first building the corpus. [FILL IN: what were the source materials — PDFs, scans, web scrapes? What did DataSquad specifically help with — collecting texts, OCR, cleaning, organizing? A sentence or two here.]
+
+[FILL IN: what was the researcher able to do once the data was ready? Even something brief like "With the texts in a usable format, [researcher] was able to run frequency analyses across editions spanning five decades."]
+
+Not every project is about cleaning a CSV. If you're working on something text-heavy and wondering whether there's a computational angle, [book a consultation](https://calendar.library.ucla.edu/widget/appointments?u=0&lid=6691&gid=27076&t=Schedule+an+In-Person+Consultation) and let's find out.

--- a/_drafts/2025-israeli-archives-download.md
+++ b/_drafts/2025-israeli-archives-download.md
@@ -1,0 +1,23 @@
+---
+title: "Downloading 1,200 Declassified Government Documents So a Researcher Didn't Have To"
+author: [FILL IN]
+date: 2025-04-01  # TODO: update before publishing
+layout: blogs
+draft: true
+---
+
+<!-- DRAFT — stub for Lian to develop. See project board issue #31 for details.
+     Core story: researcher needed bulk download of Israeli state archive PDFs from Google Pinpoint.
+     DataSquad built a scraper. Confirm researcher is okay being named before publishing. -->
+
+**The problem:** [FILL IN: researcher name], a [FILL IN: department/affiliation] researcher, needed access to over 1,200 declassified Israeli government meeting minutes spanning the 1940s through the 1980s. The documents were hosted on Google Pinpoint — accessible, but with no bulk export option. Downloading them one by one would have taken weeks.
+
+**What we did:** We built a script to automate the downloads, pulling all the PDFs into a structured local directory in a fraction of the time.
+
+**Tools used:** [FILL IN: Python? requests/selenium? confirm with whoever worked on this]
+
+**Why it matters:** Automating repetitive data collection tasks is one of the most direct ways we can free up a researcher's time. In this case it turned weeks of manual clicking into [FILL IN: how long did it actually take to run?].
+
+If you're staring down a large collection of documents with no easy way to get them all at once, that's something we can help with.
+
+[Book a consultation &rarr;](https://calendar.library.ucla.edu/widget/appointments?u=0&lid=6691&gid=27076&t=Schedule+an+In-Person+Consultation)

--- a/_drafts/2025-japanese-magazine-ocr.md
+++ b/_drafts/2025-japanese-magazine-ocr.md
@@ -1,0 +1,21 @@
+---
+title: "OCR Doesn't Speak 1930s Japanese (But We Found Tools That Do)"
+author: [FILL IN]
+date: 2025-04-01  # TODO: update before publishing
+layout: blogs
+draft: true
+---
+
+<!-- DRAFT — stub for Lian to develop. See project board issue #14 for details.
+     Researcher: Yuki Bailey, graduate student. Task: OCR scanned 1930s Japanese magazines.
+     Tested Manga OCR and other tools. Confirm findings and whether Yuki is okay being named. -->
+
+**The problem:** Standard OCR tools — the kind that work fine on modern English text — struggle badly with pre-war Japanese typography. Yuki Bailey, a graduate student [FILL IN: department], needed to extract text from scanned images of 1930s Japanese literary magazines for [FILL IN: brief description of their research].
+
+**What we did:** We tested several OCR pipelines to find what actually worked on this material, including Manga OCR, which is trained on Japanese text and handles older typefaces better than general-purpose tools. [FILL IN: what did we land on? How well did it work? Any caveats?]
+
+**Tools tested:** Manga OCR, [FILL IN: others?]
+
+**The takeaway:** OCR is never one-size-fits-all. Language, era, and print quality all affect which tool is right. If you're working with non-English historical documents and have hit a wall with standard approaches, we may be able to help.
+
+[Book a consultation &rarr;](https://calendar.library.ucla.edu/widget/appointments?u=0&lid=6691&gid=27076&t=Schedule+an+In-Person+Consultation)

--- a/_drafts/2025-libinsight-python-pipeline.md
+++ b/_drafts/2025-libinsight-python-pipeline.md
@@ -1,0 +1,23 @@
+---
+title: "Cleaning Library Data Once — and Never Having to Do It Again"
+author: [FILL IN]
+date: 2025-04-01  # TODO: update before publishing
+layout: blogs
+draft: true
+---
+
+<!-- DRAFT — stub for Lian to develop. See project board issue #13 for details.
+     Client: UCLA Library assessment committee / TFLT. Task: standardize LibInsight instruction
+     data exports, build reproducible Python workflow. Confirm who the contact was and details. -->
+
+**The problem:** The UCLA Library's assessment team was working with instruction data exported from LibInsight — but every time a new export came in, someone had to clean and reformat it by hand. Same work, every quarter.
+
+**What we did:** We built a Python pipeline that standardizes the exports automatically: [FILL IN: what did it actually do? column renaming, deduplication, date normalization, output format?]. Now the team runs the script instead of re-doing the cleanup.
+
+**Tools used:** Python, pandas, [FILL IN: others?]
+
+**Why it matters:** Reproducible workflows aren't just a time saver — they also reduce errors that creep in when the same manual process gets done slightly differently each time. If something is worth cleaning once, it's worth scripting.
+
+This kind of work sits at the intersection of library operations and data infrastructure. If your team has a recurring data task that always takes longer than it should, we'd love to hear about it.
+
+[Book a consultation &rarr;](https://calendar.library.ucla.edu/widget/appointments?u=0&lid=6691&gid=27076&t=Schedule+an+In-Person+Consultation)

--- a/_drafts/2025-llm-keyword-tagging.md
+++ b/_drafts/2025-llm-keyword-tagging.md
@@ -1,0 +1,23 @@
+---
+title: "Using AI to Tag a Research Dataset — Without Reading Every Row"
+author: [FILL IN]
+date: 2025-04-01  # TODO: update before publishing
+layout: blogs
+draft: true
+---
+
+<!-- DRAFT — stub for Lian to develop. See project board issue #6 for details.
+     Researcher: Mehrnaz Bastani. Task: auto-tag CSV dataset with keywords.
+     Explored KeyBERT and LLM-based approaches. Confirm details with whoever worked on this. -->
+
+**The problem:** [FILL IN: researcher name, Mehrnaz Bastani] had a dataset — [FILL IN: what kind of data? what field?] — and needed a way to automatically assign keyword tags to each entry. Reading through and tagging manually wasn't feasible at scale.
+
+**What we did:** We explored a few approaches, including KeyBERT (a keyword extraction library built on top of BERT language models) and [FILL IN: LLM-based approach — what model/method?]. [FILL IN: what did we end up recommending or building? Did it work well?]
+
+**Tools used:** Python, KeyBERT, [FILL IN: others]
+
+**The takeaway:** NLP-based tagging is genuinely useful when you have a large corpus and a rough sense of the vocabulary you're looking for. It's not perfect, but it can get you most of the way there fast. [FILL IN: any honest caveats about accuracy, review step needed, etc.]
+
+Research data often needs more structure than it arrives with. If you're working with a large text dataset and thinking about how to organize or search it, come talk to us.
+
+[Book a consultation &rarr;](https://calendar.library.ucla.edu/widget/appointments?u=0&lid=6691&gid=27076&t=Schedule+an+In-Person+Consultation)

--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -1,41 +1,29 @@
-<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].blog.section | default: "blog" }}">
-    <div class="container">
-        <div class="row">
-        <div class="col-lg-12 text-center">
-            <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].blog.title | default: "Our Blog" }}</h2>
-            <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].blog.text | default: "" }}</h3>
-        </div>
+<section class="bg-light page-section" id="{{ site.data.sitetext[site.locale].blog.section | default: 'blog' }}">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12 text-center">
+        <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].blog.title | default: "Our Blog" }}</h2>
+        <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].blog.text | default: "" }}</h3>
+      </div>
     </div>
+
+    <div class="row justify-content-center mt-4">
+      <div class="col-lg-8 col-md-10">
+        {% assign sorted_posts = site.posts | sort: "date" | reverse %}
+        {% for post in sorted_posts %}
+        <article class="blog-entry">
+          <h3 class="blog-entry-title">
+            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+          </h3>
+          <p class="blog-entry-meta">
+            <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+            {% if post.author %}
+            <span class="blog-entry-author">&middot; {{ post.author }}</span>
+            {% endif %}
+          </p>
+        </article>
+        {% endfor %}
+      </div>
     </div>
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-12">
-                <table class="table">
-                    <thead>
-                      <tr>
-                        <th scope="col">Date</th>
-                        <th scope="col">Title</th>
-                        <th scope="col">Author</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                    {% assign sorted_posts = site.posts | sort: "date" | reverse %}
-                    {% for post in sorted_posts %}
-                    <tr>
-                        <td>
-                            {{post.date | date: "%m-%d-%Y"}}
-                        </td>
-                        <td>
-                            <a href="{{ site.baseurl }}{{ post.url }}">{{post.title | truncate: 90, "…"}}</a>
-                        </td>
-                        <td>
-                            {{post.author}}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+  </div>
 </section>

--- a/_sass/layout/_blog.scss
+++ b/_sass/layout/_blog.scss
@@ -1,4 +1,39 @@
-// Styling for the blog section
+// Blog listing — editorial article list
+.blog-entry {
+  padding-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid $gray-200;
+  &:last-child {
+    border-bottom: none;
+  }
+  .blog-entry-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    a {
+      color: $gray-900;
+      text-decoration: none;
+      &:hover {
+        color: $primary;
+        text-decoration: none;
+      }
+      &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: 3px;
+        border-radius: 2px;
+      }
+    }
+  }
+  .blog-entry-meta {
+    font-size: 0.82rem;
+    color: $gray-600;
+    margin-bottom: 0;
+    time { font-variant-numeric: tabular-nums; }
+    .blog-entry-author { margin-left: 0.2em; }
+  }
+}
+
+// Legacy blog grid (unused but kept for reference)
 #blog {
   .blog-item {
     right: 0;
@@ -13,9 +48,9 @@
         position: absolute;
         width: 100%;
         height: 100%;
-        -webkit-transition: all ease 0.5s;
-        -moz-transition: all ease 0.5s;
-        transition: all ease 0.5s;
+        -webkit-transition: opacity 0.5s ease;
+        -moz-transition: opacity 0.5s ease;
+        transition: opacity 0.5s ease;
         opacity: 0;
         background: fade-out($primary, 0.1);
         &:hover {


### PR DESCRIPTION
## Summary

- Replaces the plain table blog index with an editorial article list
- Post titles are dark (#212529) for readability — turn UCLA Gold on hover
- Dates now display as "January 30, 2025" instead of "01-30-2025", using semantic `<time>` elements
- Fixes `transition: all` anti-pattern in legacy blog SCSS
- Adds five draft posts in `_drafts/` for Lian to complete and publish

## Draft posts included

| File | Status |
|---|---|
| `2025-dnd-racialization.md` | Full draft — model post, ready for Lian to fill in [FILL IN] placeholders |
| `2025-israeli-archives-download.md` | Stub |
| `2025-japanese-magazine-ocr.md` | Stub |
| `2025-llm-keyword-tagging.md` | Stub |
| `2025-libinsight-python-pipeline.md` | Stub |

Preview drafts locally with `bundle exec jekyll serve --drafts`

## What's held back

- Navbar/brand changes (`nav.html`, `navheader.html`, `_navbar.scss`)
- `_data/style.yml` (UCLA Gold primary color) — held with navbar work
- `_includes/head.html` (Inter font, favicon) — held with navbar work

## Test plan

- [ ] Blog listing shows dark titles that turn gold on hover
- [ ] Dates render as "Month D, YYYY" format
- [ ] All existing posts still link correctly
- [ ] Draft posts visible with `--drafts` flag, hidden in normal build

🤖 Generated with [Claude Code](https://claude.com/claude-code)